### PR TITLE
Added badges to README.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build OpenSearch Dashboard from source, run tests and release.
+name: Publish to Snap Store
 
 env:
   RELEASE: edge

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # OpenSearch Dasboards Snap
+[![Release](https://github.com/canonical/opensearch-dashboards-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opensearch-dashboards-snap/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/opensearch-dashboards-snap/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/opensearch-dashboards-snap/actions/workflows/ci.yaml)
+
 
 [//]: # (<h1 align="center">)
 [//]: # (  <a href="https://opensearch.org/">)


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* Snap Store Release
* Tests

@juditnovak I renamed the `release.yaml` workflow to condense the badge title a bit. Do let me know if this poses an issue I haven't thought about! 