### PR TITLE
[DPE-4876] Kibana Exporter application

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,3 +164,19 @@ jobs:
             echo "ERROR: Logfile unaccessible. Aborting..." >&2
             exit 1
           fi
+
+      - name: Test Prometheus Exporter
+        run: |
+          URL=http://localhost:9684/metrics
+
+          # Wait until the service esteblishes
+          exporter_ok=$(curl -i ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused  | grep "200 OK")
+          if [ ! "$exporter_ok" ]; then
+            echo "ERROR: Prometheus exporter unavailable. Aborting..." >&2
+            exit 1
+          fi

--- a/helpers/get-conf.sh
+++ b/helpers/get-conf.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+
+function get_yaml_prop() {
+    local target_file="${1}"
+    local full_key_path="${2}"
+    local default="${3}"
+
+    value=$( cat $target_file | grep -v "^#" | grep $full_key_path | tr -s [:blank:] | cut -d' ' -f 2 )
+
+    if [ $value ]
+    then
+        echo $value
+        return
+    fi
+    echo $default
+}

--- a/helpers/get-conf.sh
+++ b/helpers/get-conf.sh
@@ -6,12 +6,5 @@ function get_yaml_prop() {
     local full_key_path="${2}"
     local default="${3}"
 
-    value=$( cat $target_file | grep -v "^#" | grep $full_key_path | tr -s [:blank:] | cut -d' ' -f 2 )
-
-    if [ $value ]
-    then
-        echo $value
-        return
-    fi
-    echo $default
+   "${SNAP}"/bin/yq ".\"${full_key_path}\" // \"${default}\"" "${target_file}"
 }

--- a/scripts/wrappers/start-exporter.sh
+++ b/scripts/wrappers/start-exporter.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source "${OPS_ROOT}"/helpers/get-conf.sh
+
+function fetch_exporter_args () {
+    DASHBOARDS_HOST=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.host" "localhost" )
+    DASHBOARDS_PORT=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.port" "5601" )
+    DASHBOARDS_USERNAME=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.username" "kibanaserver" )
+    DASHBOARDS_PASSWORD=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.password" "kibanaserver" )
+}
+
+function start_kibana_exporter () {
+    "${SNAP}"/usr/bin/setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon -- \
+        ${OPENSEARCH_DASHBOARDS_DEPS_BIN}/kibana-prometheus-exporter \
+        -kibana.uri http://${DASHBOARDS_HOST}:${DASHBOARDS_PORT} \
+        -kibana.username ${DASHBOARDS_USERNAME} -kibana.password ${DASHBOARDS_PASSWORD} -kibana.skip-tls true
+}
+
+
+fetch_exporter_args
+start_kibana_exporter

--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -2,18 +2,6 @@
 
 set -eu
 
-
-# Args
-# host - The host/IP where where the dashboard is to be exposed
-# port - Port where the dashboard is to be exposed
-# opensearch - The same as the opensearch.hosts configuration parameter
-
-function parse_args () {
-    host="$(snapctl get host)"
-    port="$(snapctl get port)"
-    opensearch="$(snapctl get opensearch)"
-}
-
 function start_opensearch_dashboards () {
     # start
     "${SNAP}"/usr/bin/setpriv \
@@ -23,9 +11,7 @@ function start_opensearch_dashboards () {
         ${OPENSEARCH_DASHBOARDS_BIN}/opensearch-dashboards \
         -c ${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml \
         -l ${OPENSEARCH_DASHBOARDS_VARLOG}/opensearch_dashboards.log
+
 }
-
-
-parse_args
 
 start_opensearch_dashboards

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,17 @@ architectures:
   - build-on: amd64
 
 
+package-repositories:
+  - type: apt
+    components: [main]
+    suites: [jammy]
+    # key-id: 6676E3F1A76ADBE4488944BF7D1A96D4BF78C79E
+    # url: https://ppa.launchpadcontent.net/data-platform/prometheus-kibana-exporter/ubuntu
+    # Temoorary solution,soon to be switched to the above
+    key-id: DF1E9DB3451282198C6BED4D2D3ED538C4441E6D
+    url: https://ppa.launchpadcontent.net/lvoytek/dp-prometheus-kibana-exporter/ubuntu
+
+
 system-usernames:
   snap_daemon: shared
 
@@ -36,13 +47,14 @@ environment:
 
   SNAP_LOG_DIR: ${SNAP_COMMON}/ops/snap/logs
 
-  OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
+  OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch-dashboards
 
 
   # Read-only spaces -- executables
 
   OPENSEARCH_DASHBOARDS_RO_HOME: ${SNAP_CURRENT}/usr/share/opensearch-dashboards
   OPENSEARCH_DASHBOARDS_BIN: ${OPENSEARCH_DASHBOARDS_RO_HOME}/bin
+  OPENSEARCH_DASHBOARDS_DEPS_BIN: ${SNAP_CURRENT}/usr/bin
   NODE_HOME: ${OPENSEARCH_DASHBOARDS_RO_HOME}/node
 
   # Read-write spaces
@@ -56,7 +68,7 @@ environment:
 
 
 apps:
-  daemon:
+  opensearch-dashboards-daemon:
     daemon: simple
     install-mode: disable
     command: opt/opensearch-dashboards/start.sh
@@ -66,6 +78,17 @@ apps:
       - network
       - network-bind
 
+  kibana-exporter-daemon:
+    daemon: simple
+    install-mode: disable
+    command: opt/opensearch-dashboards/start-exporter.sh
+    restart-condition: always
+    restart-delay: 20s
+    plugs:
+      - network
+      - network-bind
+
+
 parts:
   dependencies:
     plugin: nil
@@ -74,6 +97,7 @@ parts:
     stage-packages:
       - util-linux
       - curl
+      - prometheus-kibana-exporter
 
   wrapper-scripts:
     plugin: nil
@@ -112,7 +136,7 @@ parts:
       curl  -L -o "${archive}" "${url}"
 
       # Extract and arrange
-      tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
+      tar -xzf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
 
       mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ apps:
     install-mode: disable
     command: opt/opensearch-dashboards/start-exporter.sh
     restart-condition: always
-    restart-delay: 20s
+    restart-delay: 5s
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,13 @@ system-usernames:
   snap_daemon: shared
 
 
+slots:
+  logs:
+    interface: content
+    source:
+      read:
+        - ${SNAP_COMMON}/var/log/opensearch-dashboards
+
 hooks:
   install:
     plugs:


### PR DESCRIPTION
Adding the  [Canonical build version](https://launchpad.net/~data-platform/+archive/ubuntu/prometheus-kibana-exporter) of the [`kibana-exporter` application](https://github.com/chamilad/kibana-prometheus-exporter) to the Opensearch Dashboards snap.