### PR TITLE
[DPE-4896} Minor fix on log slot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,3 +180,12 @@ jobs:
             echo "ERROR: Prometheus exporter unavailable. Aborting..." >&2
             exit 1
           fi
+
+      - name: Test Logs slot
+        run: |
+          logs_slot_avail=$(sudo snap connections opensearch-dashboards | grep opensearch-dashboards:logs)
+
+          if [ ! "$logs_slot_avail" ]; then
+            echo "ERROR: Logs slot is not available. Aborting..." >&2
+            exit 1
+          fi

--- a/scripts/wrappers/start-exporter.sh
+++ b/scripts/wrappers/start-exporter.sh
@@ -12,7 +12,7 @@ function fetch_exporter_args () {
 }
 
 function start_kibana_exporter () {
-    "${SNAP}"/usr/bin/setpriv \
+    exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon -- \

--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -4,7 +4,7 @@ set -eu
 
 function start_opensearch_dashboards () {
     # start
-    "${SNAP}"/usr/bin/setpriv \
+    exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon -- \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ slots:
     interface: content
     source:
       read:
-        - ${SNAP_COMMON}/var/log/opensearch-dashboards
+        - $SNAP_COMMON/var/log/opensearch-dashboards
 
 hooks:
   install:


### PR DESCRIPTION
We were getting the following error:

```
ubuntu@juju-af6ba0-0:~$ sudo snap restart opensearch-dashboards 
Restarted.
WARNING: There is 1 new warning. See 'snap warnings'.
ubuntu@juju-af6ba0-0:~$ sudo snap warnings
last-occurrence:  today at 14:42 UTC
warning: |
  snap "opensearch-dashboards" has bad plugs or slots: logs (content interface path is invalid:
  "${SNAP_COMMON}/var/log/opensearch-dashboards" contains a reserved apparmor char from ?*[]{}^")
```

and the slot was not getting published. Fix provided in this PR together with a test