### PR TITLE
[DPE-4898] Exporter: HTTP/HTTPS connection to OSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,9 +177,48 @@ jobs:
             --retry-max-time 60 \
             --retry-connrefused  | grep "200 OK")
           if [ ! "$exporter_ok" ]; then
-            echo "ERROR: Prometheus exporter unavailable. Aborting..." >&2
+            echo "ERROR: Prometheus exporter unavailable (connected to OSD on HTTP). Aborting..." >&2
             exit 1
           fi
+
+          echo "Successfully connected to the Exporter service"
+
+          sudo snap set opensearch-dashboards scheme=https
+          sudo snap restart opensearch-dashboards
+          sleep 10 
+
+          # Wait until the service esteblishes
+          exporter_ok=$(curl -i ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused  || true )
+          if [ "$exporter_ok" ]; then
+            echo "ERROR: Prometheus exporter available when it should be connecting to a non-existent service. Aborting..." >&2
+            exit 1
+          fi
+
+          echo "Exporter was down when it was supposed to be"
+
+          # Wrong setting defaults to HTTP
+          sudo snap set opensearch-dashboards scheme=httpblabla
+          sudo snap restart opensearch-dashboards
+          sleep 10
+
+          # Wait until the service esteblishes
+          exporter_ok=$(curl -i ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused  | grep "200 OK")
+          if [ ! "$exporter_ok" ]; then
+            echo "ERROR: Prometheus exporter unavailable (connected to OSD on HTTP). Aborting..." >&2
+            exit 1
+          fi
+
+          echo "Snap defaults correctly applied as Exporter settings"
 
       - name: Test Logs slot
         run: |

--- a/scripts/wrappers/start-exporter.sh
+++ b/scripts/wrappers/start-exporter.sh
@@ -9,6 +9,12 @@ function fetch_exporter_args () {
     DASHBOARDS_PORT=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.port" "5601" )
     DASHBOARDS_USERNAME=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.username" "kibanaserver" )
     DASHBOARDS_PASSWORD=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.password" "kibanaserver" )
+    SCHEME=$(snapctl get scheme)
+
+    TLS_ARGS=""
+    if [ "${SCHEME}" == "https" ]; then
+        TLS_ARGS="-kibana.skip-tls true"
+    fi
 }
 
 function start_kibana_exporter () {
@@ -17,8 +23,8 @@ function start_kibana_exporter () {
         --reuid snap_daemon \
         --regid snap_daemon -- \
         ${OPENSEARCH_DASHBOARDS_DEPS_BIN}/kibana-prometheus-exporter \
-        -kibana.uri http://${DASHBOARDS_HOST}:${DASHBOARDS_PORT} \
-        -kibana.username ${DASHBOARDS_USERNAME} -kibana.password ${DASHBOARDS_PASSWORD} -kibana.skip-tls true
+        -kibana.uri ${SCHEME}://${DASHBOARDS_HOST}:${DASHBOARDS_PORT} \
+        -kibana.username ${DASHBOARDS_USERNAME} -kibana.password ${DASHBOARDS_PASSWORD} ${TLS_ARGS}
 }
 
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+scheme=$(snapctl get scheme)
+if [ -z "${scheme}" ] || [ "${scheme}" != "https" ]; then
+    scheme="http"
+fi
+snapctl set scheme="${scheme}"


### PR DESCRIPTION
We need to be able to switch between HTTP and HTTPS endpoints of the Dashboards on the level of the snap.

This PR introduces this option using the 

```
snap set opensearch-dashboards scheme=https
```
command

NOTE: since we are not testing Dashboads with TLS, we can only verify the HTTP setting. Manual testing confirmed correct usage.