### PR TITLE
Use Data Platform PPA for the Kibana exporter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
     needs:
       - ci-tests
     steps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,11 +21,8 @@ package-repositories:
   - type: apt
     components: [main]
     suites: [jammy]
-    # key-id: 6676E3F1A76ADBE4488944BF7D1A96D4BF78C79E
-    # url: https://ppa.launchpadcontent.net/data-platform/prometheus-kibana-exporter/ubuntu
-    # Temoorary solution,soon to be switched to the above
-    key-id: DF1E9DB3451282198C6BED4D2D3ED538C4441E6D
-    url: https://ppa.launchpadcontent.net/lvoytek/dp-prometheus-kibana-exporter/ubuntu
+    key-id: 6676E3F1A76ADBE4488944BF7D1A96D4BF78C79E
+    url: https://ppa.launchpadcontent.net/data-platform/prometheus-kibana-exporter/ubuntu
 
 
 system-usernames:


### PR DESCRIPTION
This PR replaces the used kibana exporter PPA by the one from Data Platform