### PR TITLE
[DPE-5448] OSD v2.16 (re-set to 'main' branch)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup the required system configs OpenSearch
         run: |
-          sudo snap install opensearch --channel=2/edge --revision=56
+          sudo snap install opensearch --channel=2/edge --revision=57
           sudo snap connect opensearch:process-control
 
           sudo sysctl -w vm.swappiness=0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch-dashboards
 base: core22
 
-version: '2.15.0'
+version: '2.16.0'
 
 summary: 'OpenSearch Dashboards: community-driven OpenSearch visualization suite.'
 description: |


### PR DESCRIPTION
Since v215 was released avter v216, we prefer to re-set `main` to the highest supported version.