### PR TITLE
Update the release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload snapcraft logs
         if: ${{ failure() && steps.publish.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapcraft-release-logs
           path: ~/.local/state/snapcraft/log/


### PR DESCRIPTION
The upload-artifact v3 has been deprecated. We need to move ot v4 now.