### PR TITLE
[DPE-6873] Add Trivy to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
           scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/
           format: "sarif"
           output: "trivy-results.sarif"
+          scanners: "vuln"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,14 +67,6 @@ jobs:
 
           sudo snap install opensearch-dashboards_${version}_amd64.snap --dangerous --jailmode
 
-      - name: Import locally
-        run: |
-          full_version="$(cat rockcraft.yaml | yq .version)"
-          sudo rockcraft.skopeo   --insecure-policy \
-              copy \
-              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
-              docker-daemon:trivy/charmed-mongodb:test
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -93,10 +85,10 @@ jobs:
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
         uses: aquasecurity/trivy-action@master
         with:
-          scan-type: "image"
+          scan-type: "fs"
+          scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/
           format: "spdx-json"
           output: "dependency-results.sbom.json"
-          image-ref: "trivy/charmed-mongodb:test"
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: "MEDIUM,HIGH,CRITICAL"
           scanners: "vuln"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,6 @@ jobs:
           scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/
           format: "sarif"
           output: "trivy-results.sarif"
-          severity: "MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,13 @@ jobs:
       - name: Upload trivy report as a Github artifact
         uses: actions/upload-artifact@v4
         with:
+          name: trivy-results.sarif
+          path: "${{ github.workspace }}/trivy-results.sarif"
+          retention-days: 90
+
+      - name: Upload trivy report as a Github artifact
+        uses: actions/upload-artifact@v4
+        with:
           name: trivy-sbom-report
           path: "${{ github.workspace }}/dependency-results.sbom.json"
           retention-days: 90

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           sudo snap install opensearch-dashboards_${version}_amd64.snap --dangerous --jailmode
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           scan-type: "fs"
           scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/
@@ -83,7 +83,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           scan-type: "fs"
           scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,69 @@ jobs:
           name: opensearch-dashboards_snap_amd64
           path: "opensearch-dashboards_*.snap"
 
+  scan:
+    name: Trivy scan and SBOM Generation
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download snap file for OpenSearch Dashboards
+        uses: actions/download-artifact@v4
+        with:
+          name: opensearch-dashboards_snap_amd64
+          path: .
+
+      - name: Install snap file for Opensearch Dashboards
+        run: |
+          version="$(yq .version < snap/snapcraft.yaml)"
+
+          sudo snap install opensearch-dashboards_${version}_amd64.snap --dangerous --jailmode
+
+      - name: Import locally
+        run: |
+          full_version="$(cat rockcraft.yaml | yq .version)"
+          sudo rockcraft.skopeo   --insecure-policy \
+              copy \
+              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
+              docker-daemon:trivy/charmed-mongodb:test
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: /snap/opensearch-dashboards/current/usr/share/opensearch-dashboards/
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "MEDIUM,HIGH,CRITICAL"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "image"
+          format: "spdx-json"
+          output: "dependency-results.sbom.json"
+          image-ref: "trivy/charmed-mongodb:test"
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+          severity: "MEDIUM,HIGH,CRITICAL"
+          scanners: "vuln"
+
+      - name: Upload trivy report as a Github artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-sbom-report
+          path: "${{ github.workspace }}/dependency-results.sbom.json"
+          retention-days: 90
+
   test:
     name: Test Snap
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR extends our CI to also run trivy against the built snap. We will use the `fs` type to scan the subfolder containing our assets.