### PR TITLE
[DPE-7486] Regular snap from LP source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build Snap
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 100
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
@@ -51,19 +51,18 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version}/${{env.RELEASE}}"
+          channel="${version%%.*}/${{env.RELEASE}}"
           
-          echo "release: ${channel}/lp-${version}"
-          # echo "version=${version}" >> $GITHUB_ENV
-          # echo "channel=${channel}" >> $GITHUB_ENV
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
 
-      # - name: Publish snap to Store
-      #   uses: snapcore/action-publish@v1
-      #   env:
-      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      #   with:
-      #     snap: opensearch_${{env.version}}_amd64.snap
-      #     release: ${{env.channel}}/lp-${{env.version}}
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}/dpe-7434
 
   scan:
     name: Trivy scan and SBOM Generation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build Snap
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
@@ -48,6 +48,23 @@ jobs:
           name: opensearch-dashboards_snap_amd64
           path: "opensearch-dashboards_*.snap"
 
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version}/${{env.RELEASE}}"
+          
+          echo "release: ${channel}/lp-${version}"
+          # echo "version=${version}" >> $GITHUB_ENV
+          # echo "channel=${channel}" >> $GITHUB_ENV
+
+      # - name: Publish snap to Store
+      #   uses: snapcore/action-publish@v1
+      #   env:
+      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      #   with:
+      #     snap: opensearch_${{env.version}}_amd64.snap
+      #     release: ${{env.channel}}/lp-${{env.version}}
+
   scan:
     name: Trivy scan and SBOM Generation
     needs: build
@@ -69,23 +86,6 @@ jobs:
           version="$(yq .version < snap/snapcraft.yaml)"
 
           sudo snap install opensearch-dashboards_${version}_amd64.snap --dangerous --jailmode
-
-      - name: Set snap release channel
-        run: |
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version}/${{env.RELEASE}}"
-          
-          echo "release: ${channel}/lp-${version}"
-          # echo "version=${version}" >> $GITHUB_ENV
-          # echo "channel=${channel}" >> $GITHUB_ENV
-
-      # - name: Publish snap to Store
-      #   uses: snapcore/action-publish@v1
-      #   env:
-      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      #   with:
-      #     snap: opensearch_${{env.version}}_amd64.snap
-      #     release: ${{env.channel}}/lp-${{env.version}}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: opensearch_${{env.version}}_amd64.snap
+          snap: opensearch-dashboards_${{env.version}}_amd64.snap
           release: ${{env.channel}}/dpe-7434
 
   scan:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RELEASE: edge
+
 on:
   workflow_call:
   pull_request:
@@ -66,6 +69,23 @@ jobs:
           version="$(yq .version < snap/snapcraft.yaml)"
 
           sudo snap install opensearch-dashboards_${version}_amd64.snap --dangerous --jailmode
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version}/${{env.RELEASE}}"
+          
+          echo "release: ${channel}/lp-${version}"
+          # echo "version=${version}" >> $GITHUB_ENV
+          # echo "channel=${channel}" >> $GITHUB_ENV
+
+      # - name: Publish snap to Store
+      #   uses: snapcore/action-publish@v1
+      #   env:
+      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      #   with:
+      #     snap: opensearch_${{env.version}}_amd64.snap
+      #     release: ${{env.channel}}/lp-${{env.version}}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -1,0 +1,233 @@
+---
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Description:
+# Default configuration for OpenSearch Dashboards
+
+# OpenSearch Dashboards is served by a back end server. This setting specifies the port to use.
+# server.port: 5601
+
+# Specifies the address to which the OpenSearch Dashboards server will bind. IP addresses and host names are both valid values.
+# The default is 'localhost', which usually means remote machines will not be able to connect.
+# To allow connections from remote users, set this parameter to a non-loopback address.
+# server.host: "localhost"
+
+# Enables you to specify a path to mount OpenSearch Dashboards at if you are running behind a proxy.
+# Use the `server.rewriteBasePath` setting to tell OpenSearch Dashboards if it should remove the basePath
+# from requests it receives, and to prevent a deprecation warning at startup.
+# This setting cannot end in a slash.
+# server.basePath: ""
+
+# Specifies whether OpenSearch Dashboards should rewrite requests that are prefixed with
+# `server.basePath` or require that they are rewritten by your reverse proxy.
+# server.rewriteBasePath: false
+
+# The maximum payload size in bytes for incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The OpenSearch Dashboards server's name.  This is used for display purposes.
+# server.name: "your-hostname"
+
+# The URLs of the OpenSearch instances to use for all your queries.
+# opensearch.hosts: ["http://localhost:9200"]
+
+# OpenSearch Dashboards uses an index in OpenSearch to store saved searches, visualizations and
+# dashboards. OpenSearch Dashboards creates a new index if the index doesn't already exist.
+# opensearchDashboards.index: ".opensearch_dashboards"
+
+# The default application to load.
+# opensearchDashboards.defaultAppId: "home"
+
+# Setting for an optimized healthcheck that only uses the local OpenSearch node to do Dashboards healthcheck.
+# This settings should be used for large clusters or for clusters with ingest heavy nodes.
+# It allows Dashboards to only healthcheck using the local OpenSearch node rather than fan out requests across all nodes.
+#
+# It requires the user to create an OpenSearch node attribute with the same name as the value used in the setting
+# This node attribute should assign all nodes of the same cluster an integer value that increments with each new cluster that is spun up
+# e.g. in opensearch.yml file you would set the value to a setting using node.attr.cluster_id:
+# Should only be enabled if there is a corresponding node attribute created in your OpenSearch config that matches the value here
+# opensearch.optimizedHealthcheckId: "cluster_id"
+
+# If your OpenSearch is protected with basic authentication, these settings provide
+# the username and password that the OpenSearch Dashboards server uses to perform maintenance on the OpenSearch Dashboards
+# index at startup. Your OpenSearch Dashboards users still need to authenticate with OpenSearch, which
+# is proxied through the OpenSearch Dashboards server.
+# opensearch.username: "opensearch_dashboards_system"
+# opensearch.password: "pass"
+
+# Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.
+# These settings enable SSL for outgoing requests from the OpenSearch Dashboards server to the browser.
+# server.ssl.enabled: false
+# server.ssl.certificate: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional settings that provide the paths to the PEM-format SSL certificate and key files.
+# These files are used to verify the identity of OpenSearch Dashboards to OpenSearch and are required when
+# xpack.security.http.ssl.client_authentication in OpenSearch is set to required.
+# opensearch.ssl.certificate: /path/to/your/client.crt
+# opensearch.ssl.key: /path/to/your/client.key
+
+# Optional setting that enables you to specify a path to the PEM file for the certificate
+# authority for your OpenSearch instance.
+# opensearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
+
+# To disregard the validity of SSL certificates, change this setting's value to 'none'.
+# opensearch.ssl.verificationMode: full
+
+# Time in milliseconds to wait for OpenSearch to respond to pings. Defaults to the value of
+# the opensearch.requestTimeout setting.
+# opensearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or OpenSearch. This value
+# must be a positive integer.
+# opensearch.requestTimeout: 30000
+
+# List of OpenSearch Dashboards client-side headers to send to OpenSearch. To send *no* client-side
+# headers, set this value to [] (an empty list).
+# opensearch.requestHeadersWhitelist: [ authorization ]
+
+# Header names and values that are sent to OpenSearch. Any custom headers cannot be overwritten
+# by client-side headers, regardless of the opensearch.requestHeadersWhitelist configuration.
+# opensearch.customHeaders: {}
+
+# Time in milliseconds for OpenSearch to wait for responses from shards. Set to 0 to disable.
+# opensearch.shardTimeout: 30000
+
+# Logs queries sent to OpenSearch. Requires logging.verbose set to true.
+# opensearch.logQueries: false
+
+# Specifies the path where OpenSearch Dashboards creates the process ID file.
+# pid.file: /var/run/opensearchDashboards.pid
+
+# Enables you to specify a file where OpenSearch Dashboards stores log output.
+# logging.dest: stdout
+
+# 2.15 Ignore 'ENOSPC' error for logging stream.
+# When set to true, the 'ENOSPC' error message will not cause the OpenSearch Dashboards process to crash. Otherwise,
+# the original behavior will be maintained. It is disabled by default.
+# logging.ignoreEnospcError: false
+
+# Set the value of this setting to true to suppress all logging output.
+# logging.silent: false
+
+# Set the value of this setting to true to suppress all logging output other than error messages.
+# logging.quiet: false
+
+# Set the value of this setting to true to log all events, including system usage information
+# and all requests.
+# logging.verbose: false
+
+# Set the interval in milliseconds to sample system and process performance
+# metrics. Minimum is 100ms. Defaults to 5000.
+# ops.interval: 5000
+
+# Specifies locale to be used for all localizable strings, dates and number formats.
+# Supported languages are the following: English - en , by default , Chinese - zh-CN .
+# i18n.locale: "en"
+
+# Set the allowlist to check input graphite Url. Allowlist is the default check list.
+# vis_type_timeline.graphiteAllowedUrls: ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite']
+
+# Set the blocklist to check input graphite Url. Blocklist is an IP list.
+# Below is an example for reference
+# vis_type_timeline.graphiteBlockedIPs: [
+#  //Loopback
+#  '127.0.0.0/8',
+#  '::1/128',
+#  //Link-local Address for IPv6
+#  'fe80::/10',
+#  //Private IP address for IPv4
+#  '10.0.0.0/8',
+#  '172.16.0.0/12',
+#  '192.168.0.0/16',
+#  //Unique local address (ULA)
+#  'fc00::/7',
+#  //Reserved IP address
+#  '0.0.0.0/8',
+#  '100.64.0.0/10',
+#  '192.0.0.0/24',
+#  '192.0.2.0/24',
+#  '198.18.0.0/15',
+#  '192.88.99.0/24',
+#  '198.51.100.0/24',
+#  '203.0.113.0/24',
+#  '224.0.0.0/4',
+#  '240.0.0.0/4',
+#  '255.255.255.255/32',
+#  '::/128',
+#  '2001:db8::/32',
+#  'ff00::/8',
+# ]
+# vis_type_timeline.graphiteBlockedIPs: []
+
+# opensearchDashboards.branding:
+#   logo:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   mark:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   loadingLogo:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   faviconUrl: ""
+#   applicationTitle: ""
+
+# Set the value of this setting to true to capture region blocked warnings and errors
+# for your map rendering services.
+# map.showRegionBlockedWarning: false%
+
+# Set the value of this setting to false to suppress search usage telemetry
+# for reducing the load of OpenSearch cluster.
+# data.search.usageTelemetry.enabled: false
+
+# 2.4 renames 'wizard.enabled: false' to 'vis_builder.enabled: false'
+# Set the value of this setting to false to disable VisBuilder
+# functionality in Visualization.
+# vis_builder.enabled: false
+
+# 2.4 New Experimental Feature
+# Set the value of this setting to true to enable the experimental multiple data source
+# support feature. Use with caution.
+# data_source.enabled: false
+# Set the value of these settings to customize crypto materials to encryption saved credentials
+# in data sources.
+# data_source.encryption.wrappingKeyName: 'changeme'
+# data_source.encryption.wrappingKeyNamespace: 'changeme'
+# data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+# 2.6 New ML Commons Dashboards Feature
+# Set the value of this setting to true to enable the ml commons dashboards
+# ml_commons_dashboards.enabled: false
+
+# 2.12 New Experimental Assistant Dashboards Feature
+# Set the value of this setting to true to enable the assistant dashboards
+# assistant.chat.enabled: false
+
+# 2.13 New Query Assistant Feature
+# Set the value of this setting to false to disable the query assistant
+# observability.query_assist.enabled: false
+
+# 2.14 Enable Ui Metric Collectors in Usage Collector
+# Set the value of this setting to true to enable UI Metric collections
+# usageCollection.uiMetric.enabled: false
+
+# 2.18 New Experimental Settings
+# Set the value to true to enable
+# assistant.alertInsight.enabled: false
+# assistant.smartAnomalyDetector.enabled: false
+# assistant.text2viz.enabled: false
+# queryEnhancements.queryAssist.summary.enabled: false
+
+opensearch.hosts: [https://localhost:9200]
+opensearch.ssl.verificationMode: none
+opensearch.username: kibanaserver
+opensearch.password: kibanaserver
+opensearch.requestHeadersWhitelist: [authorization, securitytenant]
+
+opensearch_security.multitenancy.enabled: true
+opensearch_security.multitenancy.tenants.preferred: [Private, Global]
+opensearch_security.readonly_mode.roles: [kibana_read_only]
+# Use this setting if you are running opensearch-dashboards without https
+opensearch_security.cookie.secure: false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,43 +317,63 @@ parts:
     source-depth: 1
     override-build: |
       version="$(craftctl get version)"
-
+ 
       npm install -g corepack
       corepack enable
-      corepack install
+      corepack install     
 
-      # --allow-root flag is not forwarded to build scripts, bypass check
-      rootchecker=src/setup_node_env/root/force.js
-      cp "${rootchecker}" "${rootchecker}.bak"
-      echo "module.exports = () => true" > "${rootchecker}"
+      BUILDER_HOME="/home/builder"
+      BUILDER_WORKSPACE="${BUILDER_HOME}/buildercraft"
+      useradd -m -d "${BUILDER_HOME}" builder
+      mkdir -p "${BUILDER_WORKSPACE}"
 
-      # Install dependencies and run build scripts
-      NODE_ENV=development yarn osd bootstrap
-      NODE_ENV=production scripts/use_node scripts/build --linux --skip-os-packages --skip-archives --release
+      # Copy repo content
+      shopt -s dotglob
+      cp -r "${CRAFT_PART_BUILD}"/* "${BUILDER_WORKSPACE}"
+      shopt -u dotglob
+      chown -R builder:builder "${BUILDER_WORKSPACE}"
 
-      distdir="${CRAFT_PART_BUILD}/build/opensearch-dashboards-${version}-linux-x64"
+      BUILD_OSD_SCRIPT='
+        cd "${BUILDER_WORKSPACE}"
 
-      # Build and Install plugins
-      pluginbin="${distdir}/bin/opensearch-dashboards-plugin"
-      pluginsdir="${CRAFT_PART_BUILD}/plugins"
-      mv "${CRAFT_STAGE}/plugins"/* "${pluginsdir}"
+        # Install dependencies and run build scripts
+        NODE_ENV=development yarn osd bootstrap 
+        NODE_ENV=production scripts/use_node scripts/build --linux --skip-os-packages --skip-archives --release
+      '
+        
+      runuser -u builder -- env BUILDER_WORKSPACE="${BUILDER_WORKSPACE}" bash -c "${BUILD_OSD_SCRIPT}"
 
-      for plugin_dir in "${pluginsdir}"/*; do
-        NODE_ENV=development yarn --cwd "${plugin_dir}" install
-        NODE_ENV=production yarn --cwd "${plugin_dir}" build
+      # Move plugins to opensearch-dashboards repo
+      mv "${CRAFT_STAGE}/plugins"/* "${BUILDER_WORKSPACE}/plugins"
+      chown -R builder:builder "${BUILDER_WORKSPACE}/plugins"
+      BUILD_PLUGINS_SCRIPT='
+        # Build and Install plugins
+        cd "${BUILDER_WORKSPACE}"
+        distdir="${BUILDER_WORKSPACE}/build/opensearch-dashboards-${version}-linux-x64"
+        pluginbin="${distdir}/bin/opensearch-dashboards-plugin"
+        pluginsdir="${BUILDER_WORKSPACE}/plugins"
 
-        # no consistent naming convention for the zipfile across plugins
-        artifact=$(find "${plugin_dir}/build" -maxdepth 1 -type f -name '*.zip' | head -n1)
+        for plugin_dir in "${pluginsdir}"/*; do
+          NODE_ENV=development yarn --cwd "${plugin_dir}" install
+          NODE_ENV=production yarn --cwd "${plugin_dir}" build
 
-        "${pluginbin}" install "file://${artifact}"
-      done
+          # no consistent naming convention for the zipfile across plugins
+          artifact=$(find "${plugin_dir}/build" -maxdepth 1 -type f -name '*.zip' | head -n1)
 
-      # Add back root checking script
-      mv "${rootchecker}.bak" "${distdir}/${rootchecker}"
+          "${pluginbin}" install "file://${artifact}"
+        done
+      '
+
+      runuser -u builder -- env BUILDER_WORKSPACE="${BUILDER_WORKSPACE}" version="${version}" bash -c "${BUILD_PLUGINS_SCRIPT}"
+
+      mv "${BUILDER_WORKSPACE}/build" "${CRAFT_PART_BUILD}"
+      chown -R root:root ${CRAFT_PART_BUILD}/*
+      userdel -r builder
 
       mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards"
       mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch-dashboards/"
 
+      distdir="${CRAFT_PART_BUILD}/build/opensearch-dashboards-${version}-linux-x64"
       cp "$CRAFT_PROJECT_DIR/config/opensearch_dashboards.yml" "${distdir}"/config/
       cp "${distdir}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch-dashboards/"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,7 +105,6 @@ parts:
       - yq
     stage-packages:
       - util-linux
-      - curl
       - prometheus-opensearch-dashboards-exporter
 
   wrapper-scripts:
@@ -131,35 +130,238 @@ parts:
     override-build: |
       snap install node --channel=18/stable --classic
 
+  # Plugins 
+  alerting-dashboards-plugin:
+    plugin: nil
+    source: https://git.launchpad.net/alerting-dashboards-plugin
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-build: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  anomaly-detection-dashboards-plugin:
+    plugin: nil
+    source: https://git.launchpad.net/anomaly-detection-dashboards-plugin
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-assistant:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-assistant
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-maps:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-maps
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-flow-framework:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-flow-framework
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-visualizations:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-visualizations
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  index-management-dashboards-plugin:
+    plugin: nil
+    source: https://git.launchpad.net/index-management-dashboards-plugin
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  ml-commons-dashboards:
+    plugin: nil
+    source: https://git.launchpad.net/ml-commons-dashboards
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-notifications:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-notifications
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-observability:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-observability
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  query-insights-dashboards:
+    plugin: nil
+    source: https://git.launchpad.net/query-insights-dashboards
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-query-workbench:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-query-workbench
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-reporting:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-reporting
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  dashboards-search-relevance:
+    plugin: nil
+    source: https://git.launchpad.net/dashboards-search-relevance
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  security-analytics-dashboards-plugin:
+    plugin: nil
+    source: https://git.launchpad.net/security-analytics-dashboards-plugin
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
+  security-dashboards-plugin:
+    plugin: nil
+    source: https://git.launchpad.net/security-dashboards-plugin
+    source-type: git
+    source-tag: lp-v2.19.1.0
+    source-depth: 1
+    override-stage: |
+      mkdir -p ./plugins/${CRAFT_PART_NAME}
+      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+
   opensearch-dashboards:
-    plugin: npm
-    npm-include-node: true
-    npm-node-version: 18.16.0
-    source: .
+    after:
+      - nodejs
+      - alerting-dashboards-plugin
+      - anomaly-detection-dashboards-plugin
+      - dashboards-assistant
+      - dashboards-maps
+      - dashboards-flow-framework
+      - dashboards-visualizations
+      - index-management-dashboards-plugin
+      - ml-commons-dashboards
+      - dashboards-notifications
+      - dashboards-observability
+      - query-insights-dashboards
+      - dashboards-query-workbench
+      - dashboards-reporting
+      - dashboards-search-relevance
+      - security-analytics-dashboards-plugin
+      - security-dashboards-plugin
+    plugin: nil
+    source: https://git.launchpad.net/opensearch-dashboards
+    source-type: git
+    source-tag: lp-v2.19.1
+    source-depth: 1
     override-build: |
       version="$(craftctl get version)"
-      archive="opensearch-dashboards-${version}-linux-x64.tar.gz"
 
-      # Download Opensearch Dashboards
-      url="https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/${version}/${archive}"
-      curl  -L -o "${archive}" "${url}"
+      npm install -g corepack
+      corepack enable
+      corepack install
 
-      # Extract and arrange
-      tar -xzf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
+      # --allow-root flag is not forwarded to build scripts, bypass check
+      rootchecker=src/setup_node_env/root/force.js
+      cp "${rootchecker}" "${rootchecker}.bak"
+      echo "module.exports = () => true" > "${rootchecker}"
+
+      # Install dependencies and run build scripts
+      NODE_ENV=development yarn osd bootstrap
+      NODE_ENV=production scripts/use_node scripts/build --linux --skip-os-packages --skip-archives --release
+
+      distdir="${CRAFT_PART_BUILD}/build/opensearch-dashboards-${version}-linux-x64"
+
+      # Build and Install plugins
+      pluginbin="${distdir}/bin/opensearch-dashboards-plugin"
+      pluginsdir="${CRAFT_PART_BUILD}/plugins"
+      mv "${CRAFT_STAGE}/plugins"/* "${pluginsdir}"
+
+      for plugin_dir in "${pluginsdir}"/*; do
+        NODE_ENV=development yarn --cwd "${plugin_dir}" install
+        NODE_ENV=production yarn --cwd "${plugin_dir}" build
+
+        # no consistent naming convention for the zipfile across plugins
+        artifact=$(find "${plugin_dir}/build" -maxdepth 1 -type f -name '*.zip' | head -n1)
+
+        "${pluginbin}" install "file://${artifact}"
+      done
+
+      # Add back root checking script
+      mv "${rootchecker}.bak" "${distdir}/${rootchecker}"
 
       mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards"
-
       mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch-dashboards/"
-      mv "${CRAFT_PART_INSTALL}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch-dashboards/"
+
+      cp "$CRAFT_PROJECT_DIR/config/opensearch_dashboards.yml" "${distdir}"/config/
+      cp "${distdir}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch-dashboards/"
 
       declare -a resources=(
-        assets  bin  data  manifest.yml  node  node_modules  package.json  plugins  src LICENSE.txt  NOTICE.txt  README.txt
+        assets  bin  data  node  node_modules  package.json  plugins  src LICENSE.txt  NOTICE.txt  README.txt
       )
 
       for res in "${resources[@]}"; do
-          mv "${CRAFT_PART_INSTALL}/${res}" "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards/"
+          mv "${distdir}/${res}" "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards/"
       done
       chmod -R 755 "${CRAFT_PART_INSTALL}/usr/share/opensearch-dashboards/bin"
-
-      # Final clean-up
-      rm "${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -138,8 +138,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-build: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   anomaly-detection-dashboards-plugin:
     plugin: nil
@@ -148,8 +148,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-assistant:
     plugin: nil
@@ -158,8 +158,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-maps:
     plugin: nil
@@ -168,8 +168,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-flow-framework:
     plugin: nil
@@ -178,8 +178,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-visualizations:
     plugin: nil
@@ -188,8 +188,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   index-management-dashboards-plugin:
     plugin: nil
@@ -198,8 +198,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   ml-commons-dashboards:
     plugin: nil
@@ -208,8 +208,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-notifications:
     plugin: nil
@@ -218,8 +218,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-observability:
     plugin: nil
@@ -228,8 +228,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   query-insights-dashboards:
     plugin: nil
@@ -238,8 +238,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-query-workbench:
     plugin: nil
@@ -248,8 +248,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-reporting:
     plugin: nil
@@ -258,8 +258,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   dashboards-search-relevance:
     plugin: nil
@@ -268,8 +268,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   security-analytics-dashboards-plugin:
     plugin: nil
@@ -278,8 +278,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   security-dashboards-plugin:
     plugin: nil
@@ -288,8 +288,8 @@ parts:
     source-tag: lp-v2.19.1.0
     source-depth: 1
     override-stage: |
-      mkdir -p ./plugins/${CRAFT_PART_NAME}
-      cp -r "${CRAFT_PART_SRC}/." ./plugins/${CRAFT_PART_NAME}
+      mkdir -p "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
+      cp -r "${CRAFT_PART_SRC}/." "${CRAFT_STAGE}/plugins/${CRAFT_PART_NAME}"
 
   opensearch-dashboards:
     after:


### PR DESCRIPTION
This PR updates snapcraft.yaml to build OpenSearch Dashboards and OpenSearch plugins from Launchpad sources instead of directly downloading the tarball.

Also adds the `opensearch_dashboards.yml` config file that is included with the tarball.

The build scripts block the root user from executing them so a temporary user is created to run builds instead.