### PR TITLE
[DPE-7808] - Add prometheus-exporter plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,6 +207,63 @@ jobs:
             exit 1
           fi
 
+      - name: Test Prometheus Exporter
+        run: |
+          URL=http://localhost:9684/metrics
+
+          # Wait until the service esteblishes
+          metrics=$(curl ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused)
+
+          if [[ "$metrics" ==  *"opensearch_dashboards_up 0.0"* ]]; then
+            echo "ERROR: Prometheus exporter unavailable (connected to OSD on HTTP). Aborting..." >&2
+            exit 1
+          fi
+
+          echo "Successfully connected to the Exporter service"
+
+          sudo snap set opensearch-dashboards scheme=https
+          sudo snap restart opensearch-dashboards
+          sleep 10
+
+          # Wait until the service establishes
+          metrics=$(curl ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused)
+
+           if [[ "$metrics" ==  *"opensearch_dashboards_up 1.0"* ]]; then
+            echo "ERROR: Prometheus exporter available when it should be connecting to a non-existent service. Aborting..." >&2
+            exit 1
+          fi
+
+          echo "Exporter was down when it was supposed to be"
+
+          # Wrong setting defaults to HTTP, so the exporter should work
+          sudo snap set opensearch-dashboards scheme=httpblabla
+          sudo snap restart opensearch-dashboards
+          sleep 10
+
+          # Wait until the service establishes
+          metrics=$(curl ${URL} \
+            --connect-timeout 5 \
+            --retry 5 \
+            --retry-delay 5 \
+            --retry-max-time 60 \
+            --retry-connrefused)
+          if [[ "$metrics" ==  *"opensearch_dashboards_up 0.0"* ]]; then
+            echo "ERROR: Prometheus exporter unavailable (connected to OSD on HTTP). Aborting..." >&2
+            exit 1
+          fi
+
+          echo "Snap defaults correctly applied as Exporter settings"
+
       - name: Test Logs slot
         run: |
           logs_slot_avail=$(sudo snap connections opensearch-dashboards | grep opensearch-dashboards:logs)

--- a/helpers/get-conf.sh
+++ b/helpers/get-conf.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+
+function get_yaml_prop() {
+    local target_file="${1}"
+    local full_key_path="${2}"
+    local default="${3}"
+
+   "${SNAP}"/bin/yq ".\"${full_key_path}\" // \"${default}\"" "${target_file}"
+}

--- a/scripts/wrappers/start-exporter.sh
+++ b/scripts/wrappers/start-exporter.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source "${OPS_ROOT}"/helpers/get-conf.sh
+
+function fetch_exporter_args () {
+    DASHBOARDS_HOST=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.host" "localhost" )
+    DASHBOARDS_PORT=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.port" "5601" )
+    DASHBOARDS_USER=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.username" "kibanaserver" )
+    DASHBOARDS_PASSWORD=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.password" "kibanaserver" )
+    SCHEME=$(snapctl get scheme)
+}
+
+function start_exporter () {
+    OPENSEARCH_DASHBOARDS_USER="${DASHBOARDS_USER}" \
+    OPENSEARCH_DASHBOARDS_PASSWORD="${DASHBOARDS_PASSWORD}" \
+    exec "${SNAP}"/usr/bin/setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon -- \
+        ${OPENSEARCH_DASHBOARDS_DEPS_BIN}/prometheus-opensearch-dashboards-exporter \
+        --url ${SCHEME}://${DASHBOARDS_HOST}:${DASHBOARDS_PORT}
+}
+
+
+fetch_exporter_args
+start_exporter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,14 @@ platforms:
   amd64:
 
 
+package-repositories:
+  - type: apt
+    components: [main]
+    suites: [noble]
+    key-id: 6676E3F1A76ADBE4488944BF7D1A96D4BF78C79E
+    url: https://ppa.launchpadcontent.net/data-platform/prometheus-opensearch-dashboards-exporter/ubuntu
+
+
 system-usernames:
   snap_daemon: shared
 
@@ -62,6 +70,9 @@ environment:
   OPENSEARCH_DASHBOARDS_VARLIB: ${SNAP_COMMON}/var/lib/opensearch-dashboards
   OPENSEARCH_DASHBOARDS_TMPDIR: ${SNAP_COMMON}/usr/share/tmp
 
+  # include the dist-packages to be able to run the exporter
+  PYTHONPATH: "$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+
 
 apps:
   opensearch-dashboards-daemon:
@@ -70,6 +81,18 @@ apps:
     command: opt/opensearch-dashboards/start.sh
     restart-condition: always
     restart-delay: 20s
+    plugs:
+      - network
+      - network-bind
+
+  exporter-daemon:
+    daemon: simple
+    after:
+      - opensearch-dashboards-daemon
+    install-mode: disable
+    command: opt/opensearch-dashboards/start-exporter.sh
+    restart-condition: always
+    restart-delay: 5s
     plugs:
       - network
       - network-bind
@@ -83,6 +106,7 @@ parts:
     stage-packages:
       - util-linux
       - curl
+      - prometheus-opensearch-dashboards-exporter
 
   wrapper-scripts:
     plugin: nil


### PR DESCRIPTION
This PR adds the prometheus-exporter plugin that was removed in #41. The snap without the plugin will reside in the `3/edge` branch.