### PR TITLE
[DPE-7804] 3.x Snap without Prometheus exporter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Setup the required system configs OpenSearch
         run: |
-          sudo snap install opensearch --channel=2/edge --revision=76
+          sudo snap install opensearch --channel=3/edge --revision=86
           sudo snap connect opensearch:process-control
 
           sudo sysctl -w vm.swappiness=0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RELEASE: edge
+
 on:
   workflow_call:
   pull_request:
@@ -44,6 +47,22 @@ jobs:
         with:
           name: opensearch-dashboards_snap_amd64
           path: "opensearch-dashboards_*.snap"
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch-dashboards_${{env.version}}_amd64.snap
+          release: ${{env.channel}}/dpe-7804
 
   scan:
     name: Trivy scan and SBOM Generation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Setup the required system configs OpenSearch
         run: |
-          sudo snap install opensearch --channel=3/edge --revision=86
+          sudo snap install opensearch --channel=3/edge --revision=87
           sudo snap connect opensearch:process-control
 
           sudo sysctl -w vm.swappiness=0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  RELEASE: edge
-
 on:
   workflow_call:
   pull_request:
@@ -47,22 +44,6 @@ jobs:
         with:
           name: opensearch-dashboards_snap_amd64
           path: "opensearch-dashboards_*.snap"
-
-      - name: Set snap release channel
-        run: |
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}"
-          
-          echo "version=${version}" >> $GITHUB_ENV
-          echo "channel=${channel}" >> $GITHUB_ENV
-
-      - name: Publish snap to Store
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: opensearch-dashboards_${{env.version}}_amd64.snap
-          release: ${{env.channel}}/dpe-7804
 
   scan:
     name: Trivy scan and SBOM Generation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - '2/edge'
+      - '3/edge'
   workflow_call:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with running and scaling your OpenSearch clusters.
 
 or:
 ```
-sudo snap install opensearch-dashboards --channel=2/edge
+sudo snap install opensearch-dashboards --channel=3/edge
 ```
 
 ### Starting OpenSearch Dashboards:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch-dashboards
 base: core24
 
-version: '2.19.2'
+version: '3.1.0'
 
 summary: 'OpenSearch Dashboards: community-driven OpenSearch visualization suite.'
 description: |
@@ -109,7 +109,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20250721150133"
+      release_date="20250725184836"
       archive="opensearch-dashboards-${version}-${patch}-${release_date}-linux-x64.tar.gz"
 
       # Download Opensearch Dashboards


### PR DESCRIPTION
This PR:
- Bumps the version to 3.1.0 and updates the tarball url
- Updates the release workflow to trigger on `3/edge` branch
- Updates the installation channel in the README

Addresses [DPE-7804]

[DPE-7804]: https://warthogs.atlassian.net/browse/DPE-7804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ