### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - '2/edge'
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   ci-tests:


### PR DESCRIPTION
Often, to resolve outdated dependencies, a simple rebuild / release of the snap is enough, so a manual release workflow simplifies this workflow