### PR TITLE
patch: Add permissions to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
     name: Trivy scan and SBOM Generation
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   ci-tests:
     name: Build and Run Tests


### PR DESCRIPTION
This PR adds `security-event` permissions to the workflow. Since the release pipeline was failing due to missing permissions [here](https://github.com/canonical/opensearch-dashboards-snap/actions/runs/28352125419). 